### PR TITLE
chore: replicate locksmith workflow updates

### DIFF
--- a/.github/copilot/mcp.json
+++ b/.github/copilot/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,12 +9,13 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install repo tools
         run: |
-          go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0
+          make install-deps
           make install-lint
 
       - name: Warm up govulncheck

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,45 +1,51 @@
-name: Copilot Agent Setup
+name: "Copilot Setup Steps"
 
 on:
   workflow_dispatch:
-
-permissions:
-  contents: read
-  packages: read
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Golang
+      - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
-      - name: Install oapi-codegen and golangci-lint
-        run: |
-          make install-deps
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-            | sh -s -- -b "$(go env GOPATH)/bin" v2.11.2
+      - name: Cache Go modules and build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: copilot-go-${{ hashFiles('go.sum', 'tools/go.sum', 'test/suites/integration/go.sum', 'test/suites/security/go.sum') }}
+          restore-keys: copilot-go-
 
       - name: Download Go module dependencies
         run: |
           go mod download
-          (cd tools && go mod download)
+          go mod download -modfile tools/go.mod
           (cd test/suites/integration && go mod download)
           (cd test/suites/security && go mod download)
 
-      - name: Compose the integration test environment
-        run: make compose
-
-      - name: Compose the security test environment
-        run: make compose-security
-
-      - name: Tear down test environments
-        if: always()
+      - name: Install repo tools
         run: |
-          make compose-down
-          make compose-security-down
+          go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
+
+      - name: Warm up govulncheck
+        run: go tool -modfile tools/go.mod govulncheck -version

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install repo tools
         run: |
           go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
+          make install-lint
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version

--- a/.github/workflows/dependabot-auto-approve.yaml
+++ b/.github/workflows/dependabot-auto-approve.yaml
@@ -19,7 +19,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JEEVES_APP_ID }}
+          client-id: ${{ secrets.JEEVES_APP_ID }}
           private-key: ${{ secrets.JEEVES_APP_PRIVATE_KEY }}
 
       - name: Dependabot metadata
@@ -40,8 +40,14 @@ jobs:
             gh pr merge --auto -s "$PR_URL"
           fi
 
-      - name: Re-approve after force-update if auto-merge was already configured
-        if: steps.metadata.outcome == 'failure' && github.event.action == 'synchronize'
+      - name: Re-approve after branch update if auto-merge was already configured
+        # Runs on synchronize events where step 4 would be skipped — i.e. when fetch-metadata
+        # either failed (outcome=failure) or returned an empty/unexpected update-type.
+        # The auto-merge check inside the script guards against re-approving major updates.
+        if: >-
+          github.event.action == 'synchronize' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-patch' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-minor'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ lint:
 	$(call cecho,Running linter for Kerberos...,$(BOLD_YELLOW))
 	@golangci-lint run --fix
 
+install-lint:
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+
 install-deps:
 	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ RESET=\033[0m
 
 LOG_VERBOSITY ?= 20
 VERSION ?= $(shell git describe --tags --always)
+GOPATH ?= $(shell go env GOPATH)
+GOBIN ?= $(GOPATH)/bin
 
 define cecho
 	@printf "${2}${1}${RESET}\n"
@@ -39,7 +41,7 @@ lint:
 	@golangci-lint run --fix
 
 install-lint:
-	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) v2.12.2
 
 install-deps:
 	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0


### PR DESCRIPTION
## Summary
- replicate the recent Dependabot auto-approve update from `locksmith`
- add or update `copilot-setup-steps.yml` based on `locksmith`
- add `.github/copilot/mcp.json`

## Notes
- `kerberos` keeps its repo-specific Copilot setup extras while adopting the newer workflow pattern