### PR TITLE
ci: match locksmith PR auto-update workflow

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -20,16 +20,31 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JEEVES_APP_ID }}
+          client-id: ${{ secrets.JEEVES_APP_ID }}
           private-key: ${{ secrets.JEEVES_APP_PRIVATE_KEY }}
 
       - name: Update out-of-date PR branches
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr list --repo "${{ github.repository }}" --base main --state open --json number \
-            --jq '.[].number' | \
-          while read -r pr; do
-            echo "Checking PR #$pr..."
-            gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
+          gh pr list --repo "${{ github.repository }}" --base main --state open --json number,author \
+            --jq '.[] | "\(.number) \(.author.login)"' | \
+          while IFS=' ' read -r pr author; do
+            echo "Checking PR #$pr (author: $author)..."
+            if [ "$author" = "dependabot[bot]" ]; then
+              # Trigger Dependabot to rebase its own branch rather than pushing directly with
+              # the Jeeves bot token. If Jeeves pushes, dependabot/fetch-metadata fails with
+              # "PR is not from Dependabot" on the resulting synchronize event, which prevents
+              # Jeeves from re-approving and re-enabling auto-merge on that PR.
+              merge_state=$(gh pr view "$pr" --repo "${{ github.repository }}" \
+                --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "ERROR")
+              if [ "$merge_state" = "BEHIND" ]; then
+                echo "PR #$pr is behind main, triggering Dependabot rebase"
+                gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+              else
+                echo "PR #$pr merge state is '$merge_state', no update needed"
+              fi
+            else
+              gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
+            fi
           done


### PR DESCRIPTION
## Summary
- match locksmith's PR auto-update workflow
- trigger `@dependabot rebase` for behind Dependabot PRs instead of rebasing them directly with the app token
- keep direct `gh pr update-branch --rebase` for non-Dependabot PRs