### PR TITLE
Split Go module and build caches

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -20,16 +20,31 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JEEVES_APP_ID }}
+          client-id: ${{ secrets.JEEVES_APP_ID }}
           private-key: ${{ secrets.JEEVES_APP_PRIVATE_KEY }}
 
       - name: Update out-of-date PR branches
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr list --repo "${{ github.repository }}" --base main --state open --json number \
-            --jq '.[].number' | \
-          while read -r pr; do
-            echo "Checking PR #$pr..."
-            gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
+          gh pr list --repo "${{ github.repository }}" --base main --state open --json number,author \
+            --jq '.[] | "\(.number) \(.author.login)"' | \
+          while IFS=' ' read -r pr author; do
+            echo "Checking PR #$pr (author: $author)..."
+            if [ "$author" = "dependabot[bot]" ]; then
+              # Trigger Dependabot to rebase its own branch rather than pushing directly with
+              # the Jeeves bot token. If Jeeves pushes, dependabot/fetch-metadata fails with
+              # "PR is not from Dependabot" on the resulting synchronize event, which prevents
+              # Jeeves from re-approving and re-enabling auto-merge on that PR.
+              merge_state=$(gh pr view "$pr" --repo "${{ github.repository }}" \
+                --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "ERROR")
+              if [ "$merge_state" = "BEHIND" ]; then
+                echo "PR #$pr is behind main, triggering Dependabot rebase"
+                gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+              else
+                echo "PR #$pr merge state is '$merge_state', no update needed"
+              fi
+            else
+              gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
+            fi
           done

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -39,15 +39,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
+          key: validate-codegen-go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
+          key: validate-codegen-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
           restore-keys: |
-            ${{ runner.os }}-go-build-
+            validate-codegen-go-build-${{ runner.os }}-
 
       - name: Codegen
         run: make codegen
@@ -93,15 +93,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
+          key: go-build-go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
+          key: go-build-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
           restore-keys: |
-            ${{ runner.os }}-go-build-
+            go-build-go-build-${{ runner.os }}-
 
       - name: Build
         run: make go-build

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -35,16 +35,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: module-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
@@ -62,19 +60,6 @@ jobs:
             exit 1
           fi
 
-      - name: Save Go module cache
-        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.module-cache.outputs.cache-primary-key }}
-
-      - name: Save Go build cache
-        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}
 
   go-build:
     runs-on: ubuntu-latest
@@ -104,16 +89,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: module-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
@@ -122,17 +105,3 @@ jobs:
 
       - name: Build
         run: make go-build
-
-      - name: Save Go module cache
-        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.module-cache.outputs.cache-primary-key }}
-
-      - name: Save Go build cache
-        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -37,14 +37,14 @@ jobs:
 
       - name: Restore Go module cache
         id: module-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
@@ -64,14 +64,14 @@ jobs:
 
       - name: Save Go module cache
         if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.module-cache.outputs.cache-primary-key }}
 
       - name: Save Go build cache
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}
@@ -106,14 +106,14 @@ jobs:
 
       - name: Restore Go module cache
         id: module-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
@@ -125,14 +125,14 @@ jobs:
 
       - name: Save Go module cache
         if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.module-cache.outputs.cache-primary-key }}
 
       - name: Save Go build cache
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -17,6 +17,39 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
+
+      - name: Compute build cache key
+        id: build-cache-key
+        run: |
+          checksum=$(
+            {
+              cat go.mod
+              [ -f go.sum ] && cat go.sum
+              cat Makefile
+              find . -type f -name '*.go' \
+                -not -path './test/suites/*' \
+                -not -path './tools/*' \
+                -print0 | sort -z | xargs -0 cat
+            } | md5sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: module-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Codegen
         run: make codegen
@@ -29,6 +62,20 @@ jobs:
             exit 1
           fi
 
+      - name: Save Go module cache
+        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.module-cache.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}
+
   go-build:
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +86,53 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
+
+      - name: Compute build cache key
+        id: build-cache-key
+        run: |
+          checksum=$(
+            {
+              cat go.mod
+              [ -f go.sum ] && cat go.sum
+              cat Makefile
+              find . -type f -name '*.go' \
+                -not -path './test/suites/*' \
+                -not -path './tools/*' \
+                -print0 | sort -z | xargs -0 cat
+            } | md5sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: module-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Build
         run: make go-build
+
+      - name: Save Go module cache
+        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.module-cache.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -50,15 +50,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('test/suites/integration/go.sum') }}
+          key: integration-test-go-mod-${{ runner.os }}-${{ hashFiles('test/suites/integration/go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-integration-${{ steps.build-cache-key.outputs.checksum }}
+          key: integration-test-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
           restore-keys: |
-            ${{ runner.os }}-go-build-integration-
+            integration-test-go-build-${{ runner.os }}-
 
       - name: Run test environment
         run: make compose

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -48,14 +48,14 @@ jobs:
 
       - name: Restore Go module cache
         id: module-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('test/suites/integration/go.sum') }}
 
       - name: Restore Go build cache
         id: build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-integration-${{ steps.build-cache-key.outputs.checksum }}
@@ -100,14 +100,14 @@ jobs:
 
       - name: Save Go module cache
         if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.module-cache.outputs.cache-primary-key }}
 
       - name: Save Go build cache
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -26,7 +26,41 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: test/suites/integration/go.mod
-          cache-dependency-path: test/suites/integration/go.sum
+          cache: false
+
+      - name: Compute build cache key
+        id: build-cache-key
+        run: |
+          checksum=$(
+            {
+              cat go.mod
+              [ -f go.sum ] && cat go.sum
+              cat Makefile
+              find . -type f -name '*.go' \
+                -not -path './test/suites/*' \
+                -not -path './tools/*' \
+                -print0 | sort -z | xargs -0 cat
+              cat test/suites/integration/go.mod test/suites/integration/go.sum
+              find test/suites/integration -type f -name '*.go' -print0 | sort -z | xargs -0 cat
+            } | md5sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: module-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('test/suites/integration/go.sum') }}
+
+      - name: Restore Go build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-integration-${{ steps.build-cache-key.outputs.checksum }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-integration-
 
       - name: Run test environment
         run: make compose
@@ -63,3 +97,17 @@ jobs:
       - name: Tear down Kerberos test environment
         if: always()
         run: make compose-down
+
+      - name: Save Go module cache
+        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.module-cache.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -46,16 +46,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: module-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('test/suites/integration/go.sum') }}
 
-      - name: Restore Go build cache
-        id: build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-integration-${{ steps.build-cache-key.outputs.checksum }}
@@ -97,17 +95,3 @@ jobs:
       - name: Tear down Kerberos test environment
         if: always()
         run: make compose-down
-
-      - name: Save Go module cache
-        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.module-cache.outputs.cache-primary-key }}
-
-      - name: Save Go build cache
-        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-security.yaml
+++ b/.github/workflows/callable-test-security.yaml
@@ -48,14 +48,14 @@ jobs:
 
       - name: Restore Go module cache
         id: module-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('test/suites/security/go.sum') }}
 
       - name: Restore Go build cache
         id: build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-security-${{ steps.build-cache-key.outputs.checksum }}
@@ -93,14 +93,14 @@ jobs:
 
       - name: Save Go module cache
         if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.module-cache.outputs.cache-primary-key }}
 
       - name: Save Go build cache
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-security.yaml
+++ b/.github/workflows/callable-test-security.yaml
@@ -26,7 +26,41 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: test/suites/security/go.mod
-          cache-dependency-path: test/suites/security/go.sum
+          cache: false
+
+      - name: Compute build cache key
+        id: build-cache-key
+        run: |
+          checksum=$(
+            {
+              cat go.mod
+              [ -f go.sum ] && cat go.sum
+              cat Makefile
+              find . -type f -name '*.go' \
+                -not -path './test/suites/*' \
+                -not -path './tools/*' \
+                -print0 | sort -z | xargs -0 cat
+              cat test/suites/security/go.mod test/suites/security/go.sum
+              find test/suites/security -type f -name '*.go' -print0 | sort -z | xargs -0 cat
+            } | md5sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: module-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('test/suites/security/go.sum') }}
+
+      - name: Restore Go build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-security-${{ steps.build-cache-key.outputs.checksum }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-security-
 
       - name: Run security tests
         run: make securitytest-json
@@ -56,3 +90,17 @@ jobs:
       - name: Tear down security test environment
         if: always()
         run: make compose-security-down
+
+      - name: Save Go module cache
+        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.module-cache.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-security.yaml
+++ b/.github/workflows/callable-test-security.yaml
@@ -46,16 +46,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: module-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('test/suites/security/go.sum') }}
 
-      - name: Restore Go build cache
-        id: build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-security-${{ steps.build-cache-key.outputs.checksum }}
@@ -90,17 +88,3 @@ jobs:
       - name: Tear down security test environment
         if: always()
         run: make compose-security-down
-
-      - name: Save Go module cache
-        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.module-cache.outputs.cache-primary-key }}
-
-      - name: Save Go build cache
-        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-security.yaml
+++ b/.github/workflows/callable-test-security.yaml
@@ -50,15 +50,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('test/suites/security/go.sum') }}
+          key: security-test-go-mod-${{ runner.os }}-${{ hashFiles('test/suites/security/go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-security-${{ steps.build-cache-key.outputs.checksum }}
+          key: security-test-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
           restore-keys: |
-            ${{ runner.os }}-go-build-security-
+            security-test-go-build-${{ runner.os }}-
 
       - name: Run security tests
         run: make securitytest-json

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -17,6 +17,39 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
+
+      - name: Compute build cache key
+        id: build-cache-key
+        run: |
+          checksum=$(
+            {
+              cat go.mod
+              [ -f go.sum ] && cat go.sum
+              cat Makefile
+              find . -type f -name '*.go' \
+                -not -path './test/suites/*' \
+                -not -path './tools/*' \
+                -print0 | sort -z | xargs -0 cat
+            } | md5sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: module-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Run unit tests with coverage
         run: make unittest-json
@@ -44,6 +77,20 @@ jobs:
           name: go-coverage-report-${{ github.sha }}
           path: build/coverage.html
 
+      - name: Save Go module cache
+        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.module-cache.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}
+
   unit-test-postgres:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +101,39 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
+
+      - name: Compute build cache key
+        id: build-cache-key
+        run: |
+          checksum=$(
+            {
+              cat go.mod
+              [ -f go.sum ] && cat go.sum
+              cat Makefile
+              find . -type f -name '*.go' \
+                -not -path './test/suites/*' \
+                -not -path './tools/*' \
+                -print0 | sort -z | xargs -0 cat
+            } | md5sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: module-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Run postgres
         run: make run-postgres
@@ -63,3 +143,17 @@ jobs:
 
       - name: Stop postgres
         run: make stop-postgres
+
+      - name: Save Go module cache
+        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.module-cache.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -37,14 +37,14 @@ jobs:
 
       - name: Restore Go module cache
         id: module-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
@@ -79,14 +79,14 @@ jobs:
 
       - name: Save Go module cache
         if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.module-cache.outputs.cache-primary-key }}
 
       - name: Save Go build cache
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}
@@ -121,14 +121,14 @@ jobs:
 
       - name: Restore Go module cache
         id: module-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
@@ -146,14 +146,14 @@ jobs:
 
       - name: Save Go module cache
         if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.module-cache.outputs.cache-primary-key }}
 
       - name: Save Go build cache
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -39,15 +39,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
+          key: unit-test-go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
+          key: unit-test-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
           restore-keys: |
-            ${{ runner.os }}-go-build-
+            unit-test-go-build-${{ runner.os }}-
 
       - name: Run unit tests with coverage
         run: make unittest-json
@@ -108,15 +108,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
+          key: unit-test-postgres-go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
+          key: unit-test-postgres-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
           restore-keys: |
-            ${{ runner.os }}-go-build-
+            unit-test-postgres-go-build-${{ runner.os }}-
 
       - name: Run postgres
         run: make run-postgres

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -35,16 +35,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: module-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
@@ -77,19 +75,6 @@ jobs:
           name: go-coverage-report-${{ github.sha }}
           path: build/coverage.html
 
-      - name: Save Go module cache
-        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.module-cache.outputs.cache-primary-key }}
-
-      - name: Save Go build cache
-        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}
 
   unit-test-postgres:
     runs-on: ubuntu-latest
@@ -119,16 +104,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: module-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ steps.build-cache-key.outputs.checksum }}
@@ -143,17 +126,3 @@ jobs:
 
       - name: Stop postgres
         run: make stop-postgres
-
-      - name: Save Go module cache
-        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.module-cache.outputs.cache-primary-key }}
-
-      - name: Save Go build cache
-        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -61,14 +61,14 @@ jobs:
 
       - name: Restore Go module cache
         id: module-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('tools/go.sum') }}
 
       - name: Restore Go build cache
         id: build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-tools-${{ steps.build-cache-key.outputs.checksum }}
@@ -86,14 +86,14 @@ jobs:
 
       - name: Save Go module cache
         if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.module-cache.outputs.cache-primary-key }}
 
       - name: Save Go build cache
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -43,7 +43,37 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: tools/go.mod
-          cache-dependency-path: tools/go.sum
+          cache: false
+
+      - name: Compute build cache key
+        id: build-cache-key
+        run: |
+          checksum=$(
+            {
+              cat tools/go.mod tools/go.sum Makefile
+              find . -type f -name '*.go' \
+                -not -path './test/suites/*' \
+                -not -path './tools/*' \
+                -print0 | sort -z | xargs -0 cat
+            } | md5sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: module-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('tools/go.sum') }}
+
+      - name: Restore Go build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-tools-${{ steps.build-cache-key.outputs.checksum }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-tools-
 
       - name: Run vulnerability scan
         run: make vulncheck-sarif
@@ -53,3 +83,17 @@ jobs:
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: build/govulncheck-report.sarif
+
+      - name: Save Go module cache
+        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.module-cache.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -59,16 +59,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: module-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('tools/go.sum') }}
 
-      - name: Restore Go build cache
-        id: build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-tools-${{ steps.build-cache-key.outputs.checksum }}
@@ -83,17 +81,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: build/govulncheck-report.sarif
-
-      - name: Save Go module cache
-        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.module-cache.outputs.cache-primary-key }}
-
-      - name: Save Go build cache
-        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -63,15 +63,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('tools/go.sum') }}
+          key: govulncheck-go-mod-${{ runner.os }}-${{ hashFiles('tools/go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-tools-${{ steps.build-cache-key.outputs.checksum }}
+          key: govulncheck-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
           restore-keys: |
-            ${{ runner.os }}-go-build-tools-
+            govulncheck-go-build-${{ runner.os }}-
 
       - name: Run vulnerability scan
         run: make vulncheck-sarif

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,14 +27,25 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - name: Cache Go modules and build cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Compute build cache key
+        id: build-cache-key
+        run: echo "checksum=${{ hashFiles('go.mod', 'go.sum', 'tools/go.mod', 'tools/go.sum', 'test/suites/integration/go.mod', 'test/suites/integration/go.sum', 'test/suites/security/go.mod', 'test/suites/security/go.sum', '**/*.go') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: module-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: copilot-go-${{ hashFiles('go.sum', 'tools/go.sum', 'test/suites/integration/go.sum', 'test/suites/security/go.sum') }}
-          restore-keys: copilot-go-
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum', 'tools/go.sum', 'test/suites/integration/go.sum', 'test/suites/security/go.sum') }}
+
+      - name: Restore Go build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: copilot-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
+          restore-keys: |
+            copilot-go-build-${{ runner.os }}-
 
       - name: Download Go module dependencies
         run: |
@@ -50,3 +61,17 @@ jobs:
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version
+
+      - name: Save Go module cache
+        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.module-cache.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,16 +31,14 @@ jobs:
         id: build-cache-key
         run: echo "checksum=${{ hashFiles('go.mod', 'go.sum', 'tools/go.mod', 'tools/go.sum', 'test/suites/integration/go.mod', 'test/suites/integration/go.sum', 'test/suites/security/go.mod', 'test/suites/security/go.sum', '**/*.go') }}" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: module-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum', 'tools/go.sum', 'test/suites/integration/go.sum', 'test/suites/security/go.sum') }}
 
-      - name: Restore Go build cache
-        id: build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: copilot-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
@@ -61,17 +59,3 @@ jobs:
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version
-
-      - name: Save Go module cache
-        if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.module-cache.outputs.cache-primary-key }}
-
-      - name: Save Go build cache
-        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,14 +33,14 @@ jobs:
 
       - name: Restore Go module cache
         id: module-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum', 'tools/go.sum', 'test/suites/integration/go.sum', 'test/suites/security/go.sum') }}
 
       - name: Restore Go build cache
         id: build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: copilot-go-build-${{ runner.os }}-${{ steps.build-cache-key.outputs.checksum }}
@@ -64,14 +64,14 @@ jobs:
 
       - name: Save Go module cache
         if: ${{ steps.module-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.module-cache.outputs.cache-primary-key }}
 
       - name: Save Go build cache
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('go.sum', 'tools/go.sum', 'test/suites/integration/go.sum', 'test/suites/security/go.sum') }}
+          key: copilot-go-mod-${{ runner.os }}-${{ hashFiles('go.sum', 'tools/go.sum', 'test/suites/integration/go.sum', 'test/suites/security/go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Summary
- split Go module and build caches in GitHub Actions workflows
- use exact module-cache keys and separate build-cache restore/save keys
- avoid carrying stale modules forward through restore-key based cache rollover
