### PR TITLE
fix(observability): rename GetMeta component name from 'observability' to 'obs'

### DIFF
--- a/internal/composer/observability/component.go
+++ b/internal/composer/observability/component.go
@@ -165,7 +165,7 @@ func (o *obs) GetMeta() []adminapi.FlowMeta {
 
 	return append([]adminapi.FlowMeta{
 		{
-			Name: "observability",
+			Name: "obs",
 			Data: fmd,
 		},
 	}, o.next.GetMeta()...)

--- a/internal/oapi/admin/gen.go
+++ b/internal/oapi/admin/gen.go
@@ -110,7 +110,7 @@ type FlowMeta struct {
 	// Data The metadata for the flow component. The structure of the metadata depends on the flow component.
 	Data FlowMeta_Data `json:"data"`
 
-	// Name The name of the flow component, e.g. "observability", "router".
+	// Name The name of the flow component, e.g. "obs", "router".
 	Name string `json:"name"`
 }
 

--- a/openapi/admin.yaml
+++ b/openapi/admin.yaml
@@ -314,7 +314,7 @@ components:
       properties:
         name:
           type: string
-          description: The name of the flow component, e.g. "observability", "router".
+          description: The name of the flow component, e.g. "obs", "router".
         data:
           type: object
           description: The metadata for the flow component. The structure of the metadata


### PR DESCRIPTION
## Problem

The observability component used two different names for itself:
- `GetMeta()` returned `Name: "observability"`
- `AddTransition()` used the component name `"obs"`

The frontend debug view maps flow transitions to pipeline component boxes by matching `FlowTransition.component` against `FlowMeta.name`. Because the names differed, no inbound or outbound badges were ever shown for the observability component.

## Fix

Rename the `GetMeta()` return value from `"observability"` to `"obs"` so both sides are consistent. Also update the example in the OAS spec description and the corresponding generated comment.

## Tests

`go test ./internal/composer/observability/...` passes.