### PR TITLE
fix(cors): align OPTIONS preflight response to 204 across all middleware

### DIFF
--- a/internal/security/cors.go
+++ b/internal/security/cors.go
@@ -73,7 +73,7 @@ func CORSMiddleware() func(http.Handler) http.Handler {
 			SetCORSHeaders(w, r.Header.Get("Origin"))
 
 			if r.Method == http.MethodOptions {
-				w.WriteHeader(http.StatusOK)
+				w.WriteHeader(http.StatusNoContent)
 				return
 			}
 
@@ -103,7 +103,7 @@ func WhitelistCORSMiddleware(allowedOrigins []string) func(http.Handler) http.Ha
 					SetCORSHeaders(w, origin)
 
 					if r.Method == http.MethodOptions {
-						w.WriteHeader(http.StatusOK)
+						w.WriteHeader(http.StatusNoContent)
 						return
 					}
 

--- a/test/suites/connector/cors_test.go
+++ b/test/suites/connector/cors_test.go
@@ -15,6 +15,19 @@ func TestCORS(t *testing.T) {
 	t.Run("allowed origin, CORS headers", func(t *testing.T) {
 		testCORS(t, "http://localhost:30100", true)
 	})
+
+	t.Run("allowed origin, OPTIONS preflight", func(t *testing.T) {
+		t.Parallel()
+		url := fmt.Sprintf("http://%s:%d", getHost(), getConnectorPort())
+		resp := options(url, t, http.Header{"Origin": []string{"http://localhost:30100"}})
+		defer resp.Body.Close()
+		verifyStatusCode(resp.StatusCode, http.StatusNoContent, t)
+		verifyHeader(resp.Header, "Access-Control-Allow-Origin", "http://localhost:30100", t)
+		verifyHeader(resp.Header, "Access-Control-Allow-Credentials", "true", t)
+		if resp.Header.Get("Access-Control-Allow-Methods") == "" {
+			t.Fatal("Expected Access-Control-Allow-Methods to be set")
+		}
+	})
 }
 
 func testCORS(t *testing.T, origin string, expectCORSHeaders bool) {

--- a/test/suites/connector/lib.go
+++ b/test/suites/connector/lib.go
@@ -136,3 +136,22 @@ func makeRequestEditorFromCookie(cookie *http.Cookie) RequestEditorFn {
 		return nil
 	}
 }
+
+func options(url string, t *testing.T, headers ...http.Header) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodOptions, url, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	for _, h := range headers {
+		for key, values := range h {
+			req.Header[key] = values
+		}
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	return resp
+}

--- a/test/suites/integration/cors_test.go
+++ b/test/suites/integration/cors_test.go
@@ -15,7 +15,7 @@ func TestCORS_admin(t *testing.T) {
 		t.Parallel()
 		url := fmt.Sprintf("http://%s:%d/api/admin/login", getHost(), getAdminPort())
 		resp := options(url, t, http.Header{"Origin": []string{"http://www.safe.com"}})
-		verifyStatusCode(resp.StatusCode, http.StatusOK, t)
+		verifyStatusCode(resp.StatusCode, http.StatusNoContent, t)
 		verifyHeader(resp.Header, "Access-Control-Allow-Origin", "http://www.safe.com", t)
 		verifyHeader(resp.Header, "Access-Control-Allow-Credentials", "true", t)
 		if resp.Header.Get("Access-Control-Allow-Methods") == "" {
@@ -64,7 +64,7 @@ func TestCORS_basicauth(t *testing.T) {
 		t.Parallel()
 		url := fmt.Sprintf("http://%s:%d/api/auth/basic/organisations/%d/login", getHost(), getAdminPort(), alwaysOrgID)
 		resp := options(url, t, http.Header{"Origin": []string{"http://www.safe.com"}})
-		verifyStatusCode(resp.StatusCode, http.StatusOK, t)
+		verifyStatusCode(resp.StatusCode, http.StatusNoContent, t)
 		verifyHeader(resp.Header, "Access-Control-Allow-Origin", "http://www.safe.com", t)
 		verifyHeader(resp.Header, "Access-Control-Allow-Credentials", "true", t)
 		if resp.Header.Get("Access-Control-Allow-Methods") == "" {
@@ -131,7 +131,7 @@ func TestCORS_gateway(t *testing.T) {
 	t.Run("OPTIONS preflight with Origin - CORS headers returned", func(t *testing.T) {
 		t.Parallel()
 		resp := options(baseURL+"/hi", t, http.Header{"Origin": []string{"http://www.something.com"}})
-		verifyStatusCode(resp.StatusCode, http.StatusOK, t)
+		verifyStatusCode(resp.StatusCode, http.StatusNoContent, t)
 		verifyHeader(resp.Header, "Access-Control-Allow-Origin", "http://www.something.com", t)
 		verifyHeader(resp.Header, "Access-Control-Allow-Credentials", "true", t)
 		if resp.Header.Get("Access-Control-Allow-Methods") == "" {


### PR DESCRIPTION
## Summary

CORS OPTIONS preflight responses were inconsistent:
- `internal/composer/router/component.go` already returned **204** for gateway preflight
- `internal/security/cors.go` returned **200** for admin/auth/connector preflight

This PR aligns all middleware to return **204 No Content** for OPTIONS preflight and updates tests accordingly.

## Changes

- **`internal/security/cors.go`** — `CORSMiddleware` and `WhitelistCORSMiddleware` now return 204 for OPTIONS preflight
- **`test/suites/integration/cors_test.go`** — 3 preflight assertions updated to expect 204 (`TestCORS_admin`, `TestCORS_basicauth`, `TestCORS_gateway`)
- **`test/suites/connector/lib.go`** — added `options()` test helper
- **`test/suites/connector/cors_test.go`** — added OPTIONS preflight sub-test expecting 204